### PR TITLE
Fix detection for SQL dumps

### DIFF
--- a/restore.js
+++ b/restore.js
@@ -1359,7 +1359,7 @@ Please check if this is a valid PostgreSQL backup file.`);
                     header.includes('CREATE') ||
                     header.includes('INSERT') ||
                     header.includes('SET ') ||
-                    header.includes('\\connect') ||
+                    header.includes('\connect') ||
                     header.includes('BEGIN;')) {
                     return 'sql';
                 }


### PR DESCRIPTION
## Summary
- correct SQL dump detection logic

## Testing
- `npm test` *(fails: Missing script)*
- `node restore.js` *(fails: Cannot find module 'keypress')*

------
https://chatgpt.com/codex/tasks/task_b_687886c10fb8833296d3f48b9b1a367b